### PR TITLE
Name only updates in one room

### DIFF
--- a/src/Message.js
+++ b/src/Message.js
@@ -112,7 +112,7 @@ module.exports = (cl) => {
                 dbentry.name = msg.set.name;
                 user.updatedb();
                 cl.server.rooms.forEach((room) => {
-                    room.updateParticipant(cl.participantId, {
+                    room.updateParticipant(cl.user._id, {
                         name: msg.set.name
                     });
                 })
@@ -155,7 +155,7 @@ module.exports = (cl) => {
                     dbentry.color = msg.color;
                     //user.updatedb();
                     cl.server.rooms.forEach((room) => {
-                        room.updateParticipant(usr.participantId, {
+                        room.updateParticipant(usr.user._id, {
                             color: msg.color
                         });
                     })

--- a/src/Room.js
+++ b/src/Room.js
@@ -97,11 +97,14 @@ class Room extends EventEmitter {
         this.server.updateRoom(this.fetchData());
     }
     updateParticipant(pid, options) {
-        let p = this.ppl.get(pid);
-        if (!p) return;
-        options.name ? this.ppl.get(pid).user.name = options.name : {};
-        options._id ? this.ppl.get(pid).user._id = options._id : {};
-        options.color ? this.ppl.get(pid).user.color = options.color : {};
+        let p = null;
+        Array.from(this.ppl).map(rpg => {
+            if(e[1].user._id == pid) p = e[1];
+        });
+        if (p == null) return;
+        options.name ? p.user.name = options.name : {};
+        options._id ? p.user._id = options._id : {};
+        options.color ? p.user.color = options.color : {};
         this.connections.filter((ofo) => ofo.participantId == p.participantId).forEach((usr) => {
             options.name ? usr.user.name = options.name : {};
             options._id ? usr.user._id = options._id : {};


### PR DESCRIPTION
Fixes a bug where the name would only update in the room the user updated it in. This was due to the usage of participantId when finding the user in each room. Because the participantId is temporary and different in every room, it only updated the name in the room the user updated it in. I hope that made sense xd